### PR TITLE
Add lenses and containers to the hmonad container

### DIFF
--- a/hmonad/Dockerfile
+++ b/hmonad/Dockerfile
@@ -19,7 +19,9 @@ RUN cabal update && cabal install \
   http-client-tls \
   http-types \
   uuid \
-  bytestring &&\
+  bytestring \
+  lens \
+  containers &&\
   rm -rf /root/.cabal/packages /root/.cabal/logs /tmp/*
 
 COPY run.sh /opt/


### PR DESCRIPTION
`lens` and `containers` are common libraries that get used in pretty much all applications. This just adds them to hmonad.